### PR TITLE
Include logging/Logging.hpp whenever ERS issues are declared, includi…

### DIFF
--- a/include/conffwk/Errors.hpp
+++ b/include/conffwk/Errors.hpp
@@ -9,7 +9,7 @@
 #define CONFFWK_ERRORS_H_
 
 #include "ers/Issue.hpp"
-#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
+#include "logging/Logging.hpp" // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 
 
 namespace dunedaq {

--- a/include/conffwk/Errors.hpp
+++ b/include/conffwk/Errors.hpp
@@ -9,6 +9,7 @@
 #define CONFFWK_ERRORS_H_
 
 #include "ers/Issue.hpp"
+#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 
 
 namespace dunedaq {


### PR DESCRIPTION
…ng note on why (TLOG() << ERSIssue only works when Logging.hpp included first)