### PR TITLE
Johnfreeman/merge fddaq v5.3.2 rc2 a9 into develop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(conffwk VERSION 2.0.0)
+project(conffwk VERSION 2.0.1)
 
 find_package(daq-cmake REQUIRED)
 

--- a/include/conffwk/DalFactory.hpp
+++ b/include/conffwk/DalFactory.hpp
@@ -38,15 +38,15 @@ public:
   static DalFactory &
   instance();
 
-  /** register DAL object creator by class name*/
-  template<class T>
-  void
-  register_dal_class(const std::string & name, const std::set<std::string>& algorithms);
+  // /** register DAL object creator by class name*/
+  // template<class T>
+  // void
+  // register_dal_class(const std::string & name, const std::set<std::string>& algorithms);
 
   /** register DAL object creator by class name*/
   template<class T>
   void
-  register_dal_class_2g(const std::string & name);
+  register_dal_class(const std::string & name);
 
   const std::string&
   get_known_class_name_ref(const std::string& name);

--- a/include/conffwk/details/Configuration.hxx
+++ b/include/conffwk/details/Configuration.hxx
@@ -77,9 +77,6 @@ template<class T>
         throw dunedaq::conffwk::Generic(ERS_HERE, text.str().c_str());
       }
 
-      // FIXME
-      assert(false);
-
     if (!objs.empty())
       {
         for (auto& i : objs)

--- a/include/conffwk/details/DalFactory.hxx
+++ b/include/conffwk/details/DalFactory.hxx
@@ -4,25 +4,12 @@
 namespace dunedaq{
 namespace conffwk{
 
-/** register DAL object creator by class name*/
-template<class T>
-void
-DalFactory::register_dal_class(const std::string & name, const std::set<std::string>& algorithms)
-{
-  std::lock_guard<std::mutex> scoped_lock(m_class_mutex);
 
-  TLOG_DEBUG(1) << "register class " << name;
-
-  if (m_classes.emplace(name, DalFactoryFunctions(boost::compute::identity<T>(), algorithms)).second == false)
-    {
-      TLOG_DEBUG(0) << "class " << name << " was already registered";
-    }
-}
 
 /** register DAL object creator by class name*/
 template<class T>
 void
-DalFactory::register_dal_class_2g(const std::string & name)
+DalFactory::register_dal_class(const std::string & name)
 {
   std::lock_guard<std::mutex> scoped_lock(m_class_mutex);
 


### PR DESCRIPTION
In light of the second fddaq-v5.3.2 candidate release, fddaq-v5.3.2-rc2-a9, this PR will merge in the changes from the patch/fddaq-v5.3.x branch of this repo (with any conflicts resolved, if needed, on this source branch for this PR
johnfreeman/merge_fddaq-v5.3.2-rc2-a9_into_develop). A test build using this branch is available at NFDT_DEV_250603_A9.

Merging is only to be done by Software Coordination.