### PR TITLE
Johnfreeman/new daq cmake for v5.3.x

### DIFF
--- a/src/DalFactory.cpp
+++ b/src/DalFactory.cpp
@@ -39,7 +39,7 @@ DalFactory::try_load_class_library(Configuration& db, const std::string& class_n
   }
   
   std::string package = file.substr(start,end-start);
-  std::string library = "lib"+package+".so";
+  std::string library = "lib"+package+"_dal.so";
   TLOG_DEBUG(1) << "Loading dal library " << library << " for class " << class_name;
 
   auto handle = dlopen(library.c_str(), RTLD_LAZY|RTLD_GLOBAL);

--- a/test/apps/dal_resolve_libs.cxx
+++ b/test/apps/dal_resolve_libs.cxx
@@ -38,7 +38,7 @@ main(int argc, char const* argv[])
         auto end = file.find("/", start);
 
         std::string package = file.substr(start,end-start);
-        std::string library = "lib"+package+".so";
+        std::string library = "lib"+package+"_dal.so";
         fmt::print("Loading library {} from {}\n", library, package);
 
         auto handle = dlopen(library.c_str(), RTLD_LAZY|RTLD_GLOBAL);


### PR DESCRIPTION
The following PR enables this package to build on its patch branch against `daq-cmake` `v3.1.0`, which contains changes described in DUNE-DAQ/daq-cmake#155. 

This is only to be merged by Software Coordination. 