### PR TITLE
Add python binding to get path to schema holding a given class

### DIFF
--- a/include/conffwk/Configuration.hpp
+++ b/include/conffwk/Configuration.hpp
@@ -1732,6 +1732,7 @@ class Configuration {
   std::list<std::string>* return_includes_pybind(const std::string& db_name);
   std::vector<std::string> subclasses_pybind(const std::string& class_name, bool all);
   std::vector<std::string> superclasses_pybind(const std::string& class_name, bool all);
+  [[nodiscard]] const std::string& get_schema_path_pybind(const std::string& class_name);
 };
 
   /**

--- a/pybindsrc/config.cpp
+++ b/pybindsrc/config.cpp
@@ -52,6 +52,8 @@ register_conffwk(py::module& m)
 	 &Configuration::get_impl_spec, "Get implementation plug-in and its parameter used to build conffwk object")
     .def("get_includes",
 	 &Configuration::return_includes_pybind, "Returns list of files included by given database.", py::arg("db_name"))
+    .def("get_schema_path",
+       &Configuration::get_schema_path_pybind, "Get path to schema file with definition of the given class", py::arg("class_name"))
     .def("get_obj",
      	 &Configuration::get_obj_pybind, "Create a configuration object containing the desired entity from the database", py::arg("class_name"), py::arg("id"))
     .def("get_objs",
@@ -67,13 +69,14 @@ register_conffwk(py::module& m)
     .def("superclasses",
 	 &Configuration::superclasses_pybind, "Get the superclasses of a single class", py::arg("class_name"), py::arg("all"))
     .def("subclasses",
-	 &Configuration::subclasses_pybind, "Get the superclasses of a single class", py::arg("class_name"), py::arg("all"))
+	 &Configuration::subclasses_pybind, "Get the subclasses of a single class", py::arg("class_name"), py::arg("all"))
     .def("test_object",
     	 &Configuration::test_object, "Test the existence of the object", py::arg("class_name"), py::arg("id"), py::arg("rlevel"), py::arg("rclasses"))
     .def("unload",
 	 &Configuration::unload, "Unload previously-loaded database")
     ;
 }
+
 
 void
 register_conffwkobject(py::module& m)

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -2110,6 +2110,10 @@ Configuration::superclasses_pybind(const std::string& class_name, bool all) {
   return c.p_superclasses;
 }
 
-
+const std::string&
+Configuration::get_schema_path_pybind(const std::string& class_name) {
+  const dunedaq::conffwk::class_t& c = this->get_class_info(class_name, false);
+  return c.p_schema_path;
+}
 } // namespace conffwk
 } // namespace dunedaq


### PR DESCRIPTION
# Description

There is currently no way in Python to find which schema file a class is defined in. This patch adds a method with a Python binding to return the path to the containing schema file given a class name.

Can be tested simply with the following
```
>>> import conffwk
>>> db=conffwk.Configuration("oksconflibs:config/daqsystemtest/example-configs.data.xml")
>>> db.get_schema_path("Application")
'/cvmfs/dunedaq-development.opensciencegrid.org/nightly/NB_DEV_251022_A9/spack-0.22.0/opt/spack/linux-almalinux9-x86_64/gcc-13.2.0/confmodel-NB_DEV_251022_A9-moazlwoyo5iimggt7nkyeeggdh3juefp/share/schema/confmodel/dunedaq.schema.xml'
>>>
```
## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

